### PR TITLE
Fixed create/update Endpoint for Timesheets

### DIFF
--- a/src/Endpoints/Timesheet.php
+++ b/src/Endpoints/Timesheet.php
@@ -79,9 +79,7 @@ class Timesheet extends BaseEndpoint
         ]);
 
         $response = $this->httpClient->post($uri, [
-            'json' => [
-                $dayEntry->toArray()
-            ]
+            'json' => $dayEntry->toArray()
         ]);
 
         return $this->dayEntryModel($response);
@@ -101,9 +99,7 @@ class Timesheet extends BaseEndpoint
         ]);
 
         $this->httpClient->post($uri, [
-            'json' => [
-                $dayEntry->toArray()
-            ]
+            'json' => $dayEntry->toArray()
         ]);
 
         return $this->find($dayEntry->id);


### PR DESCRIPTION
I tried to create a new DayEntry in my account and got the rejection from the API. Found the issue in the Endpoint and fixed it also for the update() operation.